### PR TITLE
feat: additional source secrets for links

### DIFF
--- a/files/file.go
+++ b/files/file.go
@@ -20,32 +20,34 @@ const PermDir = 0755
 // FileInfo describes a file.
 type FileInfo struct {
 	*Listing
-	Fs        afero.Fs          `json:"-"`
-	Path      string            `json:"path"`
-	Source    share.Source      `json:"source"`
-	Name      string            `json:"name"`
-	Size      int64             `json:"size"`
-	Extension string            `json:"extension"`
-	ModTime   time.Time         `json:"modified"`
-	Mode      os.FileMode       `json:"mode"`
-	IsDir     bool              `json:"isDir"`
-	IsSymlink bool              `json:"isSymlink"`
-	Type      string            `json:"type"`
-	Content   string            `json:"content,omitempty"`
-	Checksums map[string]string `json:"checksums,omitempty"`
-	Token     string            `json:"token,omitempty"`
+	Fs         afero.Fs          `json:"-"`
+	Path       string            `json:"path"`
+	Source     share.Source      `json:"source"`
+	SecretName string            `json:"secretName,omitempty"`
+	Name       string            `json:"name"`
+	Size       int64             `json:"size"`
+	ModTime    time.Time         `json:"modified"`
+	Mode       os.FileMode       `json:"mode"`
+	IsDir      bool              `json:"isDir"`
+	IsSymlink  bool              `json:"isSymlink"`
+	Extension  string            `json:"extension"`
+	Type       string            `json:"type"`
+	Content    string            `json:"content,omitempty"`
+	Checksums  map[string]string `json:"checksums,omitempty"`
+	Token      string            `json:"token,omitempty"`
 }
 
 // FileOptions are the options when getting a file info.
 type FileOptions struct {
-	Fs      afero.Fs
-	Path    string
-	Source  share.Source
-	Modify  bool
-	Expand  bool
-	Token   string
-	Checker rules.Checker
-	Content bool
+	Fs         afero.Fs
+	Path       string
+	Source     share.Source
+	SecretName string
+	Modify     bool
+	Expand     bool
+	Token      string
+	Checker    rules.Checker
+	Content    bool
 }
 
 type Presigner interface {
@@ -91,17 +93,18 @@ func stat(opts *FileOptions) (*FileInfo, error) {
 			return nil, err
 		}
 		file = &FileInfo{
-			Fs:        opts.Fs,
-			Path:      opts.Path,
-			Source:    opts.Source,
-			Name:      info.Name(),
-			ModTime:   info.ModTime(),
-			Mode:      info.Mode(),
-			IsDir:     info.IsDir(),
-			IsSymlink: IsSymlink(info.Mode()),
-			Size:      info.Size(),
-			Extension: filepath.Ext(info.Name()),
-			Token:     opts.Token,
+			Fs:         opts.Fs,
+			Path:       opts.Path,
+			Source:     opts.Source,
+			SecretName: opts.SecretName,
+			Name:       info.Name(),
+			Size:       info.Size(),
+			ModTime:    info.ModTime(),
+			Mode:       info.Mode(),
+			IsDir:      info.IsDir(),
+			IsSymlink:  IsSymlink(info.Mode()),
+			Extension:  filepath.Ext(info.Name()),
+			Token:      opts.Token,
 		}
 	}
 
@@ -128,16 +131,18 @@ func stat(opts *FileOptions) (*FileInfo, error) {
 	}
 
 	file = &FileInfo{
-		Fs:        opts.Fs,
-		Path:      opts.Path,
-		Source:    opts.Source,
-		Name:      info.Name(),
-		ModTime:   info.ModTime(),
-		Mode:      info.Mode(),
-		IsDir:     info.IsDir(),
-		Size:      info.Size(),
-		Extension: filepath.Ext(info.Name()),
-		Token:     opts.Token,
+		Fs:         opts.Fs,
+		Path:       opts.Path,
+		Source:     opts.Source,
+		SecretName: opts.SecretName,
+		Name:       info.Name(),
+		Size:       info.Size(),
+		ModTime:    info.ModTime(),
+		Mode:       info.Mode(),
+		IsDir:      info.IsDir(),
+		IsSymlink:  false,
+		Extension:  filepath.Ext(info.Name()),
+		Token:      opts.Token,
 	}
 
 	return file, nil
@@ -285,16 +290,17 @@ func (i *FileInfo) readListing(checker rules.Checker) error {
 		}
 
 		file := &FileInfo{
-			Fs:        i.Fs,
-			Name:      name,
-			Size:      f.Size(),
-			ModTime:   f.ModTime(),
-			Mode:      f.Mode(),
-			IsDir:     f.IsDir(),
-			IsSymlink: isSymlink,
-			Extension: filepath.Ext(name),
-			Path:      fPath,
-			Source:    i.Source,
+			Fs:         i.Fs,
+			Path:       fPath,
+			Source:     i.Source,
+			SecretName: i.SecretName,
+			Name:       name,
+			Size:       f.Size(),
+			ModTime:    f.ModTime(),
+			Mode:       f.Mode(),
+			IsDir:      f.IsDir(),
+			IsSymlink:  isSymlink,
+			Extension:  filepath.Ext(name),
 		}
 
 		if file.IsDir {

--- a/files/file.go
+++ b/files/file.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/afero"
 
 	"github.com/versioneer-tech/package-r/v2/rules"
-	"github.com/versioneer-tech/package-r/v2/share"
 )
 
 const PermFile = 0644
@@ -20,34 +19,30 @@ const PermDir = 0755
 // FileInfo describes a file.
 type FileInfo struct {
 	*Listing
-	Fs         afero.Fs          `json:"-"`
-	Path       string            `json:"path"`
-	Source     share.Source      `json:"source"`
-	SecretName string            `json:"secretName,omitempty"`
-	Name       string            `json:"name"`
-	Size       int64             `json:"size"`
-	ModTime    time.Time         `json:"modified"`
-	Mode       os.FileMode       `json:"mode"`
-	IsDir      bool              `json:"isDir"`
-	IsSymlink  bool              `json:"isSymlink"`
-	Extension  string            `json:"extension"`
-	Type       string            `json:"type"`
-	Content    string            `json:"content,omitempty"`
-	Checksums  map[string]string `json:"checksums,omitempty"`
-	Token      string            `json:"token,omitempty"`
+	Fs        afero.Fs          `json:"-"`
+	Path      string            `json:"path"`
+	Name      string            `json:"name"`
+	Size      int64             `json:"size"`
+	ModTime   time.Time         `json:"modified"`
+	Mode      os.FileMode       `json:"mode"`
+	IsDir     bool              `json:"isDir"`
+	IsSymlink bool              `json:"isSymlink"`
+	Extension string            `json:"extension"`
+	Type      string            `json:"type"`
+	Content   string            `json:"content,omitempty"`
+	Checksums map[string]string `json:"checksums,omitempty"`
+	Token     string            `json:"token,omitempty"`
 }
 
 // FileOptions are the options when getting a file info.
 type FileOptions struct {
-	Fs         afero.Fs
-	Path       string
-	Source     share.Source
-	SecretName string
-	Modify     bool
-	Expand     bool
-	Token      string
-	Checker    rules.Checker
-	Content    bool
+	Fs      afero.Fs
+	Path    string
+	Modify  bool
+	Expand  bool
+	Token   string
+	Checker rules.Checker
+	Content bool
 }
 
 type Presigner interface {
@@ -93,18 +88,16 @@ func stat(opts *FileOptions) (*FileInfo, error) {
 			return nil, err
 		}
 		file = &FileInfo{
-			Fs:         opts.Fs,
-			Path:       opts.Path,
-			Source:     opts.Source,
-			SecretName: opts.SecretName,
-			Name:       info.Name(),
-			Size:       info.Size(),
-			ModTime:    info.ModTime(),
-			Mode:       info.Mode(),
-			IsDir:      info.IsDir(),
-			IsSymlink:  IsSymlink(info.Mode()),
-			Extension:  filepath.Ext(info.Name()),
-			Token:      opts.Token,
+			Fs:        opts.Fs,
+			Path:      opts.Path,
+			Name:      info.Name(),
+			Size:      info.Size(),
+			ModTime:   info.ModTime(),
+			Mode:      info.Mode(),
+			IsDir:     info.IsDir(),
+			IsSymlink: IsSymlink(info.Mode()),
+			Extension: filepath.Ext(info.Name()),
+			Token:     opts.Token,
 		}
 	}
 
@@ -131,18 +124,16 @@ func stat(opts *FileOptions) (*FileInfo, error) {
 	}
 
 	file = &FileInfo{
-		Fs:         opts.Fs,
-		Path:       opts.Path,
-		Source:     opts.Source,
-		SecretName: opts.SecretName,
-		Name:       info.Name(),
-		Size:       info.Size(),
-		ModTime:    info.ModTime(),
-		Mode:       info.Mode(),
-		IsDir:      info.IsDir(),
-		IsSymlink:  false,
-		Extension:  filepath.Ext(info.Name()),
-		Token:      opts.Token,
+		Fs:        opts.Fs,
+		Path:      opts.Path,
+		Name:      info.Name(),
+		Size:      info.Size(),
+		ModTime:   info.ModTime(),
+		Mode:      info.Mode(),
+		IsDir:     info.IsDir(),
+		IsSymlink: false,
+		Extension: filepath.Ext(info.Name()),
+		Token:     opts.Token,
 	}
 
 	return file, nil
@@ -290,17 +281,15 @@ func (i *FileInfo) readListing(checker rules.Checker) error {
 		}
 
 		file := &FileInfo{
-			Fs:         i.Fs,
-			Path:       fPath,
-			Source:     i.Source,
-			SecretName: i.SecretName,
-			Name:       name,
-			Size:       f.Size(),
-			ModTime:    f.ModTime(),
-			Mode:       f.Mode(),
-			IsDir:      f.IsDir(),
-			IsSymlink:  isSymlink,
-			Extension:  filepath.Ext(name),
+			Fs:        i.Fs,
+			Path:      fPath,
+			Name:      name,
+			Size:      f.Size(),
+			ModTime:   f.ModTime(),
+			Mode:      f.Mode(),
+			IsDir:     f.IsDir(),
+			IsSymlink: isSymlink,
+			Extension: filepath.Ext(name),
 		}
 
 		if file.IsDir {

--- a/http/auth.go
+++ b/http/auth.go
@@ -96,15 +96,15 @@ func withUser(fn handleFunc) handleFunc {
 			return http.StatusInternalServerError, err
 		}
 
-		d.sources = tk.Sources
-
-		source := d.GetSource(r.URL.Query().Get("sourceName"))
+		source := share.GetSource(tk.Sources, r.URL.Query().Get("sourceName"))
 		if source != nil {
 			bucket, prefix, session := source.Connect("")
 			if session != nil {
 				d.user.Fs = afero.NewBasePathFs(s3fs.NewFs(bucket, session), prefix+"/")
 			}
 		}
+
+		d.raw = tk.Sources
 
 		return fn(w, r, d)
 	}

--- a/http/auth.go
+++ b/http/auth.go
@@ -100,9 +100,9 @@ func withUser(fn handleFunc) handleFunc {
 
 		source := d.GetSource(r.URL.Query().Get("sourceName"))
 		if source != nil {
-			bucket, session := source.Connect()
+			bucket, prefix, session := source.Connect("")
 			if session != nil {
-				d.user.Fs = afero.NewBasePathFs(s3fs.NewFs(bucket, session), "/")
+				d.user.Fs = afero.NewBasePathFs(s3fs.NewFs(bucket, session), prefix+"/")
 			}
 		}
 

--- a/http/data.go
+++ b/http/data.go
@@ -10,7 +10,6 @@ import (
 	"github.com/versioneer-tech/package-r/v2/rules"
 	"github.com/versioneer-tech/package-r/v2/runner"
 	"github.com/versioneer-tech/package-r/v2/settings"
-	"github.com/versioneer-tech/package-r/v2/share"
 
 	"github.com/versioneer-tech/package-r/v2/storage"
 	"github.com/versioneer-tech/package-r/v2/users"
@@ -24,7 +23,6 @@ type data struct {
 	server   *settings.Server
 	store    *storage.Storage
 	user     *users.User
-	sources  []share.Source
 	raw      interface{}
 }
 
@@ -48,17 +46,6 @@ func (d *data) Check(path string) bool {
 	}
 
 	return allow
-}
-
-func (d *data) GetSource(sourceName string) *share.Source {
-	if sourceName != "" && d.sources != nil {
-		for _, source := range d.sources {
-			if source.Name == sourceName {
-				return &source
-			}
-		}
-	}
-	return nil
 }
 
 func handle(fn handleFunc, prefix string, store *storage.Storage, server *settings.Server) http.Handler {

--- a/http/resource.go
+++ b/http/resource.go
@@ -338,10 +338,11 @@ type InfoResponse struct {
 }
 
 var infoHandler = withUser(func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
+	sources := d.raw.([]share.Source)
 	return renderJSON(w, r, &InfoResponse{
 		Total:   0,
 		Used:    0,
-		Sources: d.sources,
+		Sources: sources,
 	})
 
 	// file, err := files.NewFileInfo(&files.FileOptions{

--- a/http/share.go
+++ b/http/share.go
@@ -98,7 +98,7 @@ var sharePostHandler = withPermShare(func(w http.ResponseWriter, r *http.Request
 	}
 
 	const letterBytes = "0123456789abcdefghijklmnopqrstuvwxyz"
-	b := make([]byte, 8)
+	b := make([]byte, 8) //nolint:gomnd
 	for i := range b {
 		n, err := rand.Int(rand.Reader, big.NewInt(int64(len(letterBytes))))
 		if err != nil {
@@ -111,7 +111,6 @@ var sharePostHandler = withPermShare(func(w http.ResponseWriter, r *http.Request
 	var expire int64 = 0
 
 	if body.Expires != "" {
-		//nolint:govet
 		num, err := strconv.Atoi(body.Expires)
 		if err != nil {
 			return http.StatusInternalServerError, err

--- a/http/share.go
+++ b/http/share.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
 	"net/http"
 	"sort"
 	"strconv"
@@ -96,13 +97,16 @@ var sharePostHandler = withPermShare(func(w http.ResponseWriter, r *http.Request
 		return http.StatusBadRequest, fmt.Errorf("unknown source")
 	}
 
-	bytes := make([]byte, 6) //nolint:gomnd
-	_, err := rand.Read(bytes)
-	if err != nil {
-		return http.StatusInternalServerError, err
+	const letterBytes = "0123456789abcdefghijklmnopqrstuvwxyz"
+	b := make([]byte, 8)
+	for i := range b {
+		n, err := rand.Int(rand.Reader, big.NewInt(int64(len(letterBytes))))
+		if err != nil {
+			return http.StatusInternalServerError, err
+		}
+		b[i] = letterBytes[n.Int64()]
 	}
-
-	str := base64.URLEncoding.EncodeToString(bytes)
+	str := string(b)
 
 	var expire int64 = 0
 

--- a/http/share.go
+++ b/http/share.go
@@ -83,6 +83,11 @@ var shareDeleteHandler = withPermShare(func(_ http.ResponseWriter, r *http.Reque
 })
 
 var sharePostHandler = withPermShare(func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
+	source := share.GetSource(d.raw.([]share.Source), r.URL.Query().Get("sourceName"))
+	if source == nil {
+		return http.StatusBadRequest, fmt.Errorf("unknown source")
+	}
+
 	var s *share.Link
 	var body share.CreateBody
 	if r.Body != nil {
@@ -90,11 +95,6 @@ var sharePostHandler = withPermShare(func(w http.ResponseWriter, r *http.Request
 			return http.StatusBadRequest, fmt.Errorf("failed to decode body: %w", err)
 		}
 		defer r.Body.Close()
-	}
-
-	source := d.GetSource(r.URL.Query().Get("sourceName"))
-	if source == nil {
-		return http.StatusBadRequest, fmt.Errorf("unknown source")
 	}
 
 	const letterBytes = "0123456789abcdefghijklmnopqrstuvwxyz"

--- a/share/source.go
+++ b/share/source.go
@@ -107,3 +107,14 @@ func GetStringOrDefault(values map[string]string, key, defaultValue string) stri
 	}
 	return defaultValue
 }
+
+func GetSource(sources []Source, sourceName string) *Source {
+	if sources != nil && sourceName != "" {
+		for _, source := range sources {
+			if source.Name == sourceName {
+				return &source
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
allow to resolve links via a different source secret following a strict naming pattern `source---link_hash`, this allows to override access credentials (e.g. `AWS_ACCESS_KEY_ID` `AWS_SECRET_ACCESS_KEY`) and bucket details (`BUCKET_NAME`, `BUCKET_PREFIX`)