### PR TITLE
docs: Add Backround section to README.md introducing PackageR

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,25 @@
 It allows users to browse data items mounted from object storage, enrich them with metadata and share them via direct, secure presigned URLs, without proxying data through the application server.
 
 ## Table of Contents
+- [Backround](#backround)
 - [Key Features](#key-features)
 - [Configuration](#configuration)
 - [Usage](#usage)
 - [Contributing](#contributing)
 - [License](#license)
+
+## Backround
+
+PackageR is a tool built on Filebrowser and lets you manage all kinds of data formats in a single web interface. It was created to solve the problem of having to struggle with different storage options and editing tools for different data types, which often complicates workflows for teams and individual users.
+
+With packageR, you can access text files (e.g. Markdown, JSON, YAML), binary files (e.g. Excel tables, ZIP archives, images, high‑resolution satellite imagery), complex data packages (such as scientific archives with RO‑Crate metadata), and other modern formats (e.g., Parquet, Cloud Optimized GeoTIFF, and Zarr)- all without switching between separate applications.
+
+Smaller files open directly in a lightweight inline editor in your browser, while larger or proprietary formats (i.e., files that require specific software to open, such as Excel or Photoshop) are offered via signed download URLs so you can open them in your preferred desktop software.
+
+For cloud-native and packaged data, packageR provides in-browser previews and partial access where possible — supporting formats like Parquet, Cloud‑Optimized GeoTIFF (COG), and Zarr. When metadata is available (e.g., RO‑Crate metadata.json, manifest files), it is displayed without requiring a full download, while direct links to raw archives remain available for full access when needed.
+
+By unifying these capabilities in one intuitive interface, packageR minimizes load times and unnecessary indirection, and supports the FAIR principles - keeping your data findable, accessible, interoperable, and reusable. Whether you’re glancing at a single file or conducting large‑scale analyses, Package‑R saves you time and reduces complexity.
+
 
 ## Key Features
 <a name="key-features"></a>

--- a/README.md
+++ b/README.md
@@ -3,48 +3,46 @@
 # packageR
 <a name="introduction"></a>
 
-**packageR** is a lightweight tool built on top of a fork of [File Browser](https://github.com/filebrowser/filebrowser/), designed to turn large-scale object storage systems into browsable catalogs, making it easy to view and share data packages. It is developed by [Versioneer](https://versioneer.at) and [EOX](https://eox.at).
-
-It allows users to browse data items mounted from object storage, enrich them with metadata and share them via direct, secure presigned URLs, without proxying data through the application server.
+`packageR` enables users to browse and explore data items mounted from object storage, enrich them with metadata, and curate shareable data packages. Data access is provided directly via secure, presigned URLs—without routing through the application server. `packageR` is developed by [Versioneer](https://versioneer.at) and [EOX](https://eox.at).
 
 ## Table of Contents
-- [Backround](#backround)
+- [Background](#background)
 - [Key Features](#key-features)
 - [Configuration](#configuration)
 - [Usage](#usage)
 - [Contributing](#contributing)
 - [License](#license)
 
-## Backround
+## Background
 
-PackageR is a tool built on Filebrowser and lets you manage all kinds of data formats in a single web interface. It was created to solve the problem of having to struggle with different storage options and editing tools for different data types, which often complicates workflows for teams and individual users.
+`packageR` is a lightweight tool built on top of a fork of [File Browser](https://github.com/filebrowser/filebrowser/), designed to manage diverse data formats through a single, intuitive web interface. It addresses the common challenge of juggling different storage systems and editing tools for various data types—streamlining workflows for individuals and teams alike.
 
-With packageR, you can access text files (e.g. Markdown, JSON, YAML), binary files (e.g. Excel tables, ZIP archives, images, high‑resolution satellite imagery), complex data packages (such as scientific archives with RO‑Crate metadata), and other modern formats (e.g., Parquet, Cloud Optimized GeoTIFF, and Zarr)- all without switching between separate applications.
+- For structured text formats such as Markdown, JSON, and YAML—commonly used for documentation, configuration, and metadata — `packageR` offers an integrated browser-based editor.
 
-Smaller files open directly in a lightweight inline editor in your browser, while larger or proprietary formats (i.e., files that require specific software to open, such as Excel or Photoshop) are offered via signed download URLs so you can open them in your preferred desktop software.
+- For binary content, including very large files, `packageR` can generate secure, temporary download links (presigned URLs) directly connected to underlying object storage, enabling users to download and open them in their preferred desktop applications. In addition `packageR` provides in-browser previews and selective access to modern, cloud-optimized data formats such as Parquet, Cloud-Optimized GeoTIFF (COG), and Zarr (Upcoming). When available, metadata is displayed without requiring a full download. Direct links to full raw archives are also provided for comprehensive access.
 
-For cloud-native and packaged data, packageR provides in-browser previews and partial access where possible — supporting formats like Parquet, Cloud‑Optimized GeoTIFF (COG), and Zarr. When metadata is available (e.g., RO‑Crate metadata.json, manifest files), it is displayed without requiring a full download, while direct links to raw archives remain available for full access when needed.
-
-By unifying these capabilities in one intuitive interface, packageR minimizes load times and unnecessary indirection, and supports the FAIR principles - keeping your data findable, accessible, interoperable, and reusable. Whether you’re glancing at a single file or conducting large‑scale analyses, Package‑R saves you time and reduces complexity.
-
+Building on File Browser’s sharing functionality, `packageR` promotes a packaging-oriented approach over traditional file-based workflows to simplify complex data handling and support scalable, cloud-native analysis. It supports modern catalog formats such as the [STAC GeoParquet Specification](https://github.com/stac-utils/stac-geoparquet/blob/main/spec/stac-geoparquet-spec.md), allowing metadata to be embedded directly within Parquet files and previewed using tools like [STAC Browser](https://github.com/radiantearth/stac-browser).
 
 ## Key Features
 <a name="key-features"></a>
 
-- **Presigned URL Sharing**: Securely shares data items by generating presigned URLs for objects stored in systems like AWS S3, GCS, Azure Blob, or MinIO. `packageR` achieves this by browsing a local filesystem path (configured via `FB_ROOT`) which is a mount of your object storage (e.g., via FUSE, K8s CSI drivers). When a data item is accessed, `packageR` uses the provided AWS-compatible credentials to generate a direct download URL, avoiding the need to proxy data through the application server.
-- **Metadata bundling**: Supports enhancing of datasets with descriptive metadata, attestations, UI hints, and documentation. This facilitates verifiable distribution and integration with external graphical tools.
-- **Stateless Operation**: Operates without managing internal application state, aside from the share links themselves. All configurations are applied declaratively at startup.
-- **External Authentication**: Leverages proxy-based authentication methods, such as OIDC headers or JWT claims, complemented by a lightweight role mapping system.
-- **File Browser Compatibility**: Builds upon the core File Browser user interface and plugin architecture, introducing opinionated enhancements tailored for cloud-native environments.
-- **UI Customization**: Offers basic UI branding, such as setting a custom application name (via `FB_BRANDING_NAME`). More advanced visual customizations can be achieved by overriding static assets in a custom Docker image.
+- **Streamlined Data Package Generation**: Curate arbitrary data packages of any size containing both binary and text content. Share them via download links, optionally protected and with customizable expiration settings.
+
+- **Rich Previews**: Inline viewers support modern, streamable data formats such as Parquet, Cloud-Optimized GeoTIFF (COG), and Zarr—enabling easy preview and interactive exploration directly in the browser.
+
+- **Presigned URL Sharing**: Securely share data items by generating presigned URLs for objects stored in systems like AWS S3, GCS, Azure Blob, or MinIO. `packageR` works by browsing a local filesystem path (configured via `FB_ROOT`), which represents a mount of your object storage (e.g., via FUSE or Kubernetes CSI drivers). When a data item is accessed, `packageR` uses AWS-compatible credentials to generate a direct download link directly connected to underlying object storage system—bypassing the `packageR` application.
+
+- **Metadata Bundling**: Enhance datasets with rich metadata, attestations, UI hints, and documentation. This enables verifiable data distribution and smooth integration with external graphical tools.
+
+- **Stateless Operation**: Runs without managing internal application state (aside from share links). All configurations are applied declaratively at startup.
+
+- **External Authentication**: Supports proxy-based authentication mechanisms such as OIDC headers or JWT claims, and includes a lightweight role-mapping system for access control.
+
+- **UI Customization**: Allows basic user interface branding (e.g., setting a custom application name via `FB_BRANDING_NAME`). For more advanced customization, static assets can be overridden in a custom Docker image.
+
 
 ## Configuration
 <a name="configuration"></a>
-
-> ⚠️ **Important Notice**  
-> As of the latest rebase on **31 May 2025**, the repository was aligned with the latest upstream changes and underwent a cleanup of obsolete configuration options as well as the removal of outdated issues.  
-> This was done to reduce confusion caused by outdated guidance and to ensure that all relevant information is now accurately reflected in the `packageR` documentation.
-
 
 All settings are injected via environment variables:
 
@@ -97,7 +95,7 @@ docker run --rm -it \
   -e AWS_REGION=<my-region> \
   -e BUCKET_NAME=<my-bucket> \
   -p 8080:8080 \
-  package-r:v2025.6.2
+  package-r:latest
 ```
 
 This setup allows `packageR` to list and share data items from the bucket mount, generating secure presigned URLs pointing to the corresponding objects on the bucket.


### PR DESCRIPTION
**Description:**

This PR adds a new Background section to the README.md that introduces Package R.
The added section explains:
- The motivation behind creating Package R
- A rough overview of the supported file types and formats (text, binary, scientific packages, and cloud-native formats)
- How Package R handles different file types (inline editing, signed downloads, metadata previews)
- The tool's alignment with FAIR data principles

**Why this is useful:**
- Gives readers a clear understanding of what Package R does and why it exists
- Clarifies supported formats and usage scenarios
- Highlights key features and values (e.g., unified access, FAIR compliance)